### PR TITLE
Correctly capitalize uri in config

### DIFF
--- a/templates/fusiondirectory.conf.j2
+++ b/templates/fusiondirectory.conf.j2
@@ -21,7 +21,7 @@
 		        >
 {% for referral in location.referrals %}
 
-			<referral uri="{{ referral.uri }}/{{ referral.basedn }}"
+			<referral URI="{{ referral.uri }}/{{ referral.basedn }}"
 			          adminDn="{{ referral.admin }}"
 			          adminPassword="{{ referral.password }}"
 			          ldapTLS="{{ referral.tls | default('false') | upper }}"/>


### PR DESCRIPTION
While both work with FusionDirectory itself, the FusionDirectory setup
will fail at the `--check-ldap` task.